### PR TITLE
Improved README.md for Arch users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+
+.vscode
+GenCFSMs
+KMC

--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ cabal update
 cabal install cmdargs ansi-terminal parallel split MissingH --lib
 ```
 
+For Arch users, do NOT use _pacman_ and use those lines instead:
+
+```
+sudo apt install python-matplotlib
+sudo apt install python-scipy
+curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+cabal install cmdargs ansi-terminal parallel split MissingH parsec --only-dependencies
+cabal install cmdargs ansi-terminal parallel split MissingH --lib
+```
+
+Indeed, [the default Arch package for GHC has been broken for some time](https://github.com/github/semantic/issues/109#issuecomment-502778064).
+
 ## Getting started (download and compile)
 
 * Open a terminal


### PR DESCRIPTION
The default Arch package for GHC has been broken for some time, concerned users need to use GHCUp and not use Pacman